### PR TITLE
Check tags from github to see if there are new images

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -9,10 +9,7 @@ source "$rootdir/scripts/utils.sh"
 get_base_image() {
   name="${DOCKER_REPO##*/}"
   project="$(get_project "$name")"
-  registry="$(get_registry "$project")"
-  namespace="$(get_namespace "$project")"
-
-  echo "$registry/$namespace/$name:$DOCKER_TAG"
+  echo "$(get_docker_repo "$name" "$project"):$DOCKER_TAG"
 }
 
 docker build --build-arg BASE_IMAGE="$(get_base_image)" -t $IMAGE_NAME .

--- a/projects.txt
+++ b/projects.txt
@@ -1,9 +1,9 @@
-kube-proxy gcr google-containers
+kube-proxy github kubernetes/kubernetes k8s.gcr.io
 cluster-proportional-autoscaler-amd64 gcr google-containers
 pause-amd64 gcr google-containers
 pause gcr google-containers
-kube-apiserver gcr google-containers
+kube-apiserver github kubernetes/kubernetes k8s.gcr.io
 kubernetes-dashboard-amd64 gcr google-containers
-kube-scheduler gcr google-containers
+kube-scheduler github kubernetes/kubernetes k8s.gcr.io
 k8s-dns-node-cache gcr google-containers
-kube-controller-manager gcr google-containers
+kube-controller-manager github kubernetes/kubernetes k8s.gcr.io

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -21,12 +21,12 @@ get_project() {
 }
 
 get_registry_type() {
-  project="$1"
+  local project="$1"
   echo "$project" | awk '{print $2}'
 }
 
 get_registry() {
-  registry_type="$(get_registry_type "$1")"
+  local registry_type="$(get_registry_type "$1")"
   case "$registry_type" in
     gcr)
       echo "gcr.io"
@@ -39,7 +39,7 @@ get_registry() {
 }
 
 get_namespace() {
-  project="$1"
+  local project="$1"
   echo "$project" | awk '{print $3}'
 }
 
@@ -47,4 +47,32 @@ get_gcr_image_tags() {
   local name=$1
   local namespace=$2
   curl -s https://gcr.io/v2/$namespace/$name/tags/list | jq -r '.tags[]'
+}
+
+get_docker_repo() {
+  local name="$1"
+  local project="$2"
+  local registry_type="$(get_registry_type "$project")"
+  local namespace="$(get_namespace "$project")"
+
+  case "$registry_type" in
+    gcr)
+      echo "gcr.io/$namespace/$name"
+      ;;
+    github)
+      case "$namespace" in
+        kubernetes/kubernetes)
+          echo "k8s.gcr.io/$name"
+          ;;
+        *)
+          echo "Unsupported namespace: $namespace"
+          exit 1
+          ;;
+      esac
+      ;;
+    *)
+      echo "Unsupported registry: $registry_type"
+      exit 1
+      ;;
+  esac
 }


### PR DESCRIPTION
According to [this link](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#production-images-moved-to-community-control), new kubernetes images are no longer in `gcr.io`, instead they're in `k8s.gcr.io`. So checking updates from [here](https://console.cloud.google.com/gcr/images/google-containers/GLOBAL) no longer works. To fix this issue, we check if there are new tags from github repo.